### PR TITLE
fix: Prevent double trigger due to pjax

### DIFF
--- a/lib/rails_admin_clone/action.rb
+++ b/lib/rails_admin_clone/action.rb
@@ -48,6 +48,10 @@ module RailsAdmin
         register_instance_option :link_icon do
           'icon-copy fa fa-files-o'
         end
+
+        register_instance_option :pjax? do
+          false
+        end
       end
     end
   end


### PR DESCRIPTION
Using versions Rails 4.0.13 RailsAdmin 0.6.5

Saving a cloned model sometimes returns the clone link `.../admin/<model_name>/<id>/clone` It appears to be happening because the pjax call failing causing a double trigger.  https://github.com/sferik/rails_admin/wiki/Custom-action#double-pjax

Disabling pjax prevents the case of a double trigger causing the return from saving the clone to go back to the clone.