### PR TITLE
Make the gem compatible with rails_admin 3.0 (font awesome 5)

### DIFF
--- a/lib/rails_admin_clone/action.rb
+++ b/lib/rails_admin_clone/action.rb
@@ -46,7 +46,7 @@ module RailsAdmin
         end
 
         register_instance_option :link_icon do
-          'icon-copy fa fa-files-o'
+          'fa fa-copy'
         end
 
         register_instance_option :pjax? do

--- a/lib/rails_admin_clone/version.rb
+++ b/lib/rails_admin_clone/version.rb
@@ -1,3 +1,3 @@
 module RailsAdminClone
-  VERSION = "0.0.6"
+  VERSION = '0.0.7'
 end


### PR DESCRIPTION
Turns out, `fa-files-o` icon is no longer in Font Awesome 5, which is in use in rails admin 3.x. I fixed this and bumped the version. 